### PR TITLE
Redesign Checkout Header

### DIFF
--- a/ui/components/checkout/CheckoutHeader.tsx
+++ b/ui/components/checkout/CheckoutHeader.tsx
@@ -9,12 +9,12 @@ export default function CheckoutHeader() {
       <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-12">
         <div className="flex items-center justify-between">
           <Link href="/" className="flex items-center">
-            <span className="sr-only">Just One Dollar</span>
+            <span className="sr-only">Just One</span>
             <Image 
-              src="/just-one-dollar-logo.png" 
-              alt="Just One Dollar" 
-              width={120}
-              height={38}
+              src="/logo.svg" 
+              alt="Just One" 
+              width={200}
+              height={60}
               className="h-8 w-auto" 
             />
           </Link>


### PR DESCRIPTION
### Pull Request Overview
This PR updates the checkout header branding from "Just One Dollar" to "Just One" and switches from a PNG logo to an SVG format with adjusted dimensions.

### Key Changes:

- Updated brand name from "Just One Dollar" to "Just One" in accessibility text and alt text
- Changed logo file from PNG to SVG format with increased dimensions